### PR TITLE
Update for SMAPI 3.0

### DIFF
--- a/NoSeedsFromTreesFix/NoSeedsFromTreesFix.csproj
+++ b/NoSeedsFromTreesFix/NoSeedsFromTreesFix.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony">

--- a/NoSeedsFromTreesFix/NoSeedsFromTreesFix.csproj
+++ b/NoSeedsFromTreesFix/NoSeedsFromTreesFix.csproj
@@ -12,8 +12,6 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>.\0Harmony.dll</HintPath>
     </Reference>
@@ -51,17 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/NoSeedsFromTreesFix/manifest.json
+++ b/NoSeedsFromTreesFix/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
-   "Name": "NoSeedsFromTreesFix",
+   "Name": "No Seeds From Trees Fix",
    "Author": "KirbyLink",
    "Version": "1.1.0",
    "Description": "Fixes bug that causes tree seeds to not drop after Farmer levels during day.",
    "UniqueID": "kirbylink.noseedsfromtreesfix",
-   "EntryDll": "noseedsfromtreesfix.dll",
-   "MinimumApiVersion": "2.0",
+   "EntryDll": "NoSeedsFromTreesFix.dll",
+   "MinimumApiVersion": "2.0.0",
    "UpdateKeys": ["Nexus:2947"]
 }

--- a/NoSeedsFromTreesFix/packages.config
+++ b/NoSeedsFromTreesFix/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This pull request...

* Updates the manifest for SMAPI 3.0 (the `EntryDll` value will be case-sensitive for Linux/Mac compatibility).
* Updates the NuGet package and migrates to the new package reference format.
* Tweaks the manifest name (_NoSeedsFromTreesFix_ → _No Seeds From Trees Fix_).

Let me know if you want me to make any changes!